### PR TITLE
Fail gracefully on lookup error

### DIFF
--- a/geo/services/Geo_LocationService.php
+++ b/geo/services/Geo_LocationService.php
@@ -68,7 +68,7 @@ class Geo_LocationService extends BaseApplicationComponent
 
         $url = "/api/".$ip."/full";
         $nekudoClient = new \Guzzle\Http\Client("http://geoip.nekudo.com");
-        $response = $nekudoClient->get($url)->send();
+        $response = $nekudoClient->get($url, array("exceptions" => false))->send();
 
         if (!$response->isSuccessful()) {
             return array();
@@ -107,7 +107,7 @@ class Geo_LocationService extends BaseApplicationComponent
 
         $url = "/geip/".$ip;
         $telizeClient = new \Guzzle\Http\Client("http://www.telize.com");
-        $response = $telizeClient->get($url)->send();
+        $response = $telizeClient->get($url, array("exceptions" => false))->send();
 
         if (!$response->isSuccessful()) {
             return array();

--- a/geo/services/Geo_LocationService.php
+++ b/geo/services/Geo_LocationService.php
@@ -75,6 +75,9 @@ class Geo_LocationService extends BaseApplicationComponent
         }
 
         $data = json_decode($response->getBody());
+        if (property_exists($data, "type") && $data->type === "error") {
+            return array();
+        }
 
         if(isset($data->subdivisions[0])){
             $regionName = $data->subdivisions[0]->names->en;

--- a/geo/services/Geo_LocationService.php
+++ b/geo/services/Geo_LocationService.php
@@ -68,7 +68,7 @@ class Geo_LocationService extends BaseApplicationComponent
 
         $url = "/api/".$ip."/full";
         $nekudoClient = new \Guzzle\Http\Client("http://geoip.nekudo.com");
-        $response = $nekudoClient->get($url, array("exceptions" => false))->send();
+        $response = $nekudoClient->get($url, array(), array("exceptions" => false))->send();
 
         if (!$response->isSuccessful()) {
             return array();
@@ -110,7 +110,7 @@ class Geo_LocationService extends BaseApplicationComponent
 
         $url = "/geip/".$ip;
         $telizeClient = new \Guzzle\Http\Client("http://www.telize.com");
-        $response = $telizeClient->get($url, array("exceptions" => false))->send();
+        $response = $telizeClient->get($url, array(), array("exceptions" => false))->send();
 
         if (!$response->isSuccessful()) {
             return array();


### PR DESCRIPTION
Newer versions of Guzzle will throw an exception when HTTP status code signals an error. Passing the exception option reverts to the old behaviour.
Nekudo will respond with HTTP 200 even when the requested resource was not found and instead respond with a JSON object containing `{"type":"error","msg":"No record found."}`. This causes an error later when a non-existing property is read from the response.